### PR TITLE
Fix ruleset struct mismatch

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -18894,14 +18894,6 @@ func (r *RuleRequiredStatusChecks) GetIntegrationID() int64 {
 	return *r.IntegrationID
 }
 
-// GetBypassMode returns the BypassMode field if it's non-nil, zero value otherwise.
-func (r *Ruleset) GetBypassMode() string {
-	if r == nil || r.BypassMode == nil {
-		return ""
-	}
-	return *r.BypassMode
-}
-
 // GetConditions returns the Conditions field.
 func (r *Ruleset) GetConditions() *RulesetConditions {
 	if r == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -22043,16 +22043,6 @@ func TestRuleRequiredStatusChecks_GetIntegrationID(tt *testing.T) {
 	r.GetIntegrationID()
 }
 
-func TestRuleset_GetBypassMode(tt *testing.T) {
-	var zeroValue string
-	r := &Ruleset{BypassMode: &zeroValue}
-	r.GetBypassMode()
-	r = &Ruleset{}
-	r.GetBypassMode()
-	r = nil
-	r.GetBypassMode()
-}
-
 func TestRuleset_GetConditions(tt *testing.T) {
 	r := &Ruleset{}
 	r.GetConditions()

--- a/github/orgs_rules_test.go
+++ b/github/orgs_rules_test.go
@@ -27,7 +27,6 @@ func TestOrganizationsService_GetAllOrganizationRulesets(t *testing.T) {
 			"source_type": "Organization",
 			"source": "o",
 			"enforcement": "active",
-			"bypass_mode": "none",
 			"node_id": "nid",
 			"_links": {
 			  "self": {
@@ -50,7 +49,6 @@ func TestOrganizationsService_GetAllOrganizationRulesets(t *testing.T) {
 		SourceType:  String("Organization"),
 		Source:      "o",
 		Enforcement: "active",
-		BypassMode:  String("none"),
 		NodeID:      String("nid"),
 		Links: &RulesetLinks{
 			Self: &RulesetLink{HRef: String("https://api.github.com/orgs/o/rulesets/26110")},
@@ -764,7 +762,6 @@ func TestOrganizationsService_GetOrganizationRuleset(t *testing.T) {
 		SourceType:  String("Organization"),
 		Source:      "o",
 		Enforcement: "active",
-		BypassMode:  String("none"),
 		NodeID:      String("nid"),
 		Links: &RulesetLinks{
 			Self: &RulesetLink{HRef: String("https://api.github.com/orgs/o/rulesets/26110")},
@@ -853,7 +850,6 @@ func TestOrganizationsService_UpdateOrganizationRuleset(t *testing.T) {
 		Name:        "test ruleset",
 		Target:      String("branch"),
 		Enforcement: "active",
-		BypassMode:  String("none"),
 		Conditions: &RulesetConditions{
 			RefName: &RulesetRefConditionParameters{
 				Include: []string{"refs/heads/main", "refs/heads/master"},
@@ -881,7 +877,6 @@ func TestOrganizationsService_UpdateOrganizationRuleset(t *testing.T) {
 		SourceType:  String("Organization"),
 		Source:      "o",
 		Enforcement: "active",
-		BypassMode:  String("none"),
 		NodeID:      String("nid"),
 		Links: &RulesetLinks{
 			Self: &RulesetLink{HRef: String("https://api.github.com/orgs/o/rulesets/26110")},

--- a/github/repos_rules.go
+++ b/github/repos_rules.go
@@ -14,8 +14,10 @@ import (
 // BypassActor represents the bypass actors from a ruleset.
 type BypassActor struct {
 	ActorID *int64 `json:"actor_id,omitempty"`
-	// Possible values for ActorType are: Team, Integration
+	// Possible values for ActorType are: RepositoryRole, Team, Integration, OrganizationAdmin
 	ActorType *string `json:"actor_type,omitempty"`
+	// Possible values for BypassMode are: always, pull_request
+	BypassMode *string `json:"bypass_mode,omitempty"`
 }
 
 // RulesetLink represents a single link object from GitHub ruleset request _links.
@@ -327,9 +329,7 @@ type Ruleset struct {
 	SourceType *string `json:"source_type,omitempty"`
 	Source     string  `json:"source"`
 	// Possible values for Enforcement are: disabled, active, evaluate
-	Enforcement string `json:"enforcement"`
-	// Possible values for BypassMode are: none, repository, organization
-	BypassMode   *string            `json:"bypass_mode,omitempty"`
+	Enforcement  string             `json:"enforcement"`
 	BypassActors []*BypassActor     `json:"bypass_actors,omitempty"`
 	NodeID       *string            `json:"node_id,omitempty"`
 	Links        *RulesetLinks      `json:"_links,omitempty"`


### PR DESCRIPTION
The definition of a ruleset has changed in the API. This change updates the Ruleset struct to reflect what the API expects.